### PR TITLE
Add MCP Docker helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,16 @@ The hardening mechanism Codex uses depends on your OS:
   container image** and mounts your repo _read/write_ at the same path. A
   custom `iptables`/`ipset` firewall script denies all egress except the
   OpenAI API. This gives you deterministic, reproducible runs without needing
+
   root on the host. You can use the [`run_in_container.sh`](./codex-cli/scripts/run_in_container.sh) script to set up the sandbox.
+
+  To expose Codex as a Model Context Protocol (MCP) server inside the
+  container, use the [`mcp docker`](./scripts/mcp) helper. This launches the
+  container and starts the `codex mcp` server:
+
+  ```bash
+  ./scripts/mcp docker
+  ```
 
 ---
 

--- a/codex-cli/scripts/run_mcp_in_container.sh
+++ b/codex-cli/scripts/run_mcp_in_container.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -e
+
+# Usage:
+#   ./run_mcp_in_container.sh [--work_dir directory]
+#
+# Launches a Codex MCP server inside the Docker sandbox. Any additional
+# arguments are forwarded to the `codex mcp` command within the container.
+
+# Default the work directory to WORKSPACE_ROOT_DIR if not provided.
+WORK_DIR="${WORKSPACE_ROOT_DIR:-$(pwd)}"
+# Default allowed domains - can be overridden with OPENAI_ALLOWED_DOMAINS env var
+OPENAI_ALLOWED_DOMAINS="${OPENAI_ALLOWED_DOMAINS:-api.openai.com}"
+
+# Parse optional flag.
+if [ "$1" = "--work_dir" ]; then
+  if [ -z "$2" ]; then
+    echo "Error: --work_dir flag provided but no directory specified."
+    exit 1
+  fi
+  WORK_DIR="$2"
+  shift 2
+fi
+
+WORK_DIR=$(realpath "$WORK_DIR")
+
+# Generate a unique container name based on the normalized work directory
+CONTAINER_NAME="codex_$(echo "$WORK_DIR" | sed 's/\//_/g' | sed 's/[^a-zA-Z0-9_-]//g')"
+
+# Define cleanup to remove the container on script exit, ensuring no leftover containers
+cleanup() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+# Trap EXIT to invoke cleanup regardless of how the script terminates
+trap cleanup EXIT
+
+# No required positional arguments.
+
+# Check if WORK_DIR is set.
+if [ -z "$WORK_DIR" ]; then
+  echo "Error: No work directory provided and WORKSPACE_ROOT_DIR is not set."
+  exit 1
+fi
+
+# Verify that OPENAI_ALLOWED_DOMAINS is not empty
+if [ -z "$OPENAI_ALLOWED_DOMAINS" ]; then
+  echo "Error: OPENAI_ALLOWED_DOMAINS is empty."
+  exit 1
+fi
+
+# Kill any existing container for the working directory using cleanup(), centralizing removal logic.
+cleanup
+
+# Run the container with the specified directory mounted at the same path inside the container.
+docker run --name "$CONTAINER_NAME" -d \
+  -e OPENAI_API_KEY \
+  --cap-add=NET_ADMIN \
+  --cap-add=NET_RAW \
+  -v "$WORK_DIR:/app$WORK_DIR" \
+  codex \
+  sleep infinity
+
+# Write the allowed domains to a file in the container
+docker exec --user root "$CONTAINER_NAME" bash -c "mkdir -p /etc/codex"
+for domain in $OPENAI_ALLOWED_DOMAINS; do
+  # Validate domain format to prevent injection
+  if [[ ! "$domain" =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
+    echo "Error: Invalid domain format: $domain"
+    exit 1
+  fi
+  echo "$domain" | docker exec --user root -i "$CONTAINER_NAME" bash -c "cat >> /etc/codex/allowed_domains.txt"
+done
+
+# Set proper permissions on the domains file
+docker exec --user root "$CONTAINER_NAME" bash -c "chmod 444 /etc/codex/allowed_domains.txt && chown root:root /etc/codex/allowed_domains.txt"
+
+# Initialize the firewall inside the container as root user
+docker exec --user root "$CONTAINER_NAME" bash -c "/usr/local/bin/init_firewall.sh"
+
+# Remove the firewall script after running it
+docker exec --user root "$CONTAINER_NAME" bash -c "rm -f /usr/local/bin/init_firewall.sh"
+
+# Start the Codex MCP server inside the container. Any extra arguments are
+# forwarded to `codex mcp`.
+
+quoted_args=""
+for arg in "$@"; do
+  quoted_args+=" $(printf '%q' \"$arg\")"
+done
+docker exec -it "$CONTAINER_NAME" bash -c "cd \"/app$WORK_DIR\" && CODEX_RUST=1 codex mcp${quoted_args}"
+

--- a/scripts/mcp
+++ b/scripts/mcp
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ "$1" = "docker" ]; then
+  shift
+  "$SCRIPT_DIR/../codex-cli/scripts/run_mcp_in_container.sh" "$@"
+else
+  echo "Usage: mcp docker [args...]" >&2
+  exit 1
+fi
+


### PR DESCRIPTION
## Summary
- add script to run Codex as an MCP server inside Docker
- expose `mcp docker` helper for easy startup
- document running Codex's MCP server in README

## Testing
- `pnpm test` *(fails: Error when performing the request to registry.npmjs.org)*
- `pnpm run lint` *(fails: Error when performing the request to registry.npmjs.org)*
- `pnpm run typecheck` *(fails: Error when performing the request to registry.npmjs.org)*